### PR TITLE
UI fixes for mobile version

### DIFF
--- a/client/html/installation.html
+++ b/client/html/installation.html
@@ -70,6 +70,16 @@
                 0% { transform: rotate(0deg); }
                 100% { transform: rotate(360deg); }
             }
+
+            @media screen and (max-width: 767px) {
+                body, html {
+                    height: 100%;
+                }
+
+                .content.container {
+                    min-height: calc(100% - 28px);
+                }
+            }
         </style>
     </head>
     <body>

--- a/client/html/installation.html
+++ b/client/html/installation.html
@@ -79,6 +79,10 @@
                 .content.container {
                     min-height: calc(100% - 28px);
                 }
+
+                #navbar > .navbar {
+                    margin-bottom: 0px;
+                }
             }
         </style>
     </head>

--- a/client/html/installation.html
+++ b/client/html/installation.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <title>{{applicationName}}</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="{{basePath}}client/modules/treo-core/css/treo/treo-dark-theme.css">
         <link rel="shortcut icon" sizes="196x196" href="{{basePath}}client/modules/treo-core/img/favicon16x16.png">
         <link rel="icon" href="{{basePath}}client/modules/treo-core/img/favicon16x16.png" type="image/x-icon">
@@ -76,12 +77,46 @@
                     height: 100%;
                 }
 
+                .msg-box {
+                    z-index: 1000;
+                }
+
+                td {
+                    padding: 5px !important;
+                }
+
                 .content.container {
                     min-height: calc(100% - 28px);
+                    padding: 0 0;
+                }
+
+                #general-container {
+                    border: 0;
+                }
+
+                #general-container,
+                .panel-body,
+                #main-template {
+                    height: 100%;
+                }
+
+                #general-container .main-template,
+                #general-container .main-template .modal-body {
+                    min-height: unset;
                 }
 
                 #navbar > .navbar {
                     margin-bottom: 0px;
+                }
+            }
+
+            @media screen and (max-width: 320px) {
+                td {
+                    padding: 1px !important;
+                }
+
+                .modal-body {
+                    padding: 12px;
                 }
             }
         </style>

--- a/client/modules/treo-core/css/treo/treo-dark-theme.css
+++ b/client/modules/treo-core/css/treo/treo-dark-theme.css
@@ -21083,4 +21083,12 @@ select {
         height: auto;
         min-height: calc(100% - 28px);
     }
+
+    #navbar > div > div.navbar-header > a > img {
+        padding: 5px 5px 5px 0;
+    }
+
+    #main .catalog-tree-panel-hidden > button.collapse-panel {
+        z-index: auto;
+    }
 }

--- a/client/modules/treo-core/css/treo/treo-dark-theme.css
+++ b/client/modules/treo-core/css/treo/treo-dark-theme.css
@@ -19808,7 +19808,8 @@ button.category:focus {
         margin-top: 44px;
     }
 
-    .detail .panel-default > .panel-heading {
+    .detail .panel-default > .panel-heading,
+    .edit .panel-default > .panel-heading {
         margin: 0 -15px;
     }
 
@@ -21090,5 +21091,31 @@ select {
 
     #main .catalog-tree-panel-hidden > button.collapse-panel {
         z-index: auto;
+    }
+
+    .record .detail .bottom .panel .group-container {
+        margin: 0px -14px;
+    }
+
+    .record .detail .panel .panel-heading {
+        height: 28px !important;
+    }
+
+    .record .detail .panel .panel-heading > .btn-group {
+        top: -6px;
+    }
+
+    .record .detail .panel .panel-body.panel-collapse.collapse.in > .list-container {
+        position: relative;
+        top: -7px;
+        padding-top: 7px;
+    }
+
+    .record .detail .panel .panel-body.panel-body-form .form-group {
+        margin-top: 5px;
+    }
+
+    .overview.col-md-8 .panel-body.panel-body-form {
+        padding: 5px 0px;
     }
 }

--- a/client/modules/treo-core/css/treo/treo-dark-theme.css
+++ b/client/modules/treo-core/css/treo/treo-dark-theme.css
@@ -21067,6 +21067,12 @@ select {
     padding: 6px 12px 6px 12px;
 }
 
+#notifications-panel > .panel,
+.queue-panel-container > .panel {
+    box-shadow: 0px 3px 10px rgba(0, 0, 0, 0.175);
+    background-color: white;
+}
+
 @media screen and (max-width: 767px) {
     html, body {
         height: 100%;

--- a/client/modules/treo-core/css/treo/treo-dark-theme.css
+++ b/client/modules/treo-core/css/treo/treo-dark-theme.css
@@ -21124,4 +21124,12 @@ select {
     .overview.col-md-8 .panel-body.panel-body-form {
         padding: 5px 0px;
     }
+
+    .side > .panel.panel-default.panel-default {
+        margin: 0px -15px;
+    }
+
+    .side > .panel.panel-default.panel-default .panel-heading {
+        margin: 0;
+    }
 }

--- a/client/modules/treo-core/css/treo/treo-dark-theme.css
+++ b/client/modules/treo-core/css/treo/treo-dark-theme.css
@@ -21065,3 +21065,22 @@ select {
     margin-left: 0;
     padding: 6px 12px 6px 12px;
 }
+
+@media screen and (max-width: 767px) {
+    html, body {
+        height: 100%;
+    }
+
+    body {
+        height: calc(100% - 44px);
+    }
+
+    .container.content {
+        height: calc(100% + calc(44px - 28px))
+    }
+
+    header + .container.content {
+        height: auto;
+        min-height: calc(100% - 28px);
+    }
+}


### PR DESCRIPTION
82792
The footer is attached to the bottom of the page for mobile devices
Removed unnecessary indentation under the header for mobile devices in installer
Improved mobile version of the installer
Added padding to the logo in the header for the mobile version
Fixed display of arrows above of menu
UI issue fixes in bottom panels
Added shadow for notifications and queue manager panels
Fixed side margins in the side panel